### PR TITLE
update(monitor): implement a queue and avoid endless loops

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,5 +10,7 @@
         }
     ],
     "minimum-stability": "stable",
-    "require": {}
+    "require": {
+        "helga-agentur/monitor-instance": "^2.0.2"
+    }
 }

--- a/src/ApiConsumerInterface.php
+++ b/src/ApiConsumerInterface.php
@@ -29,7 +29,7 @@ interface ApiConsumerInterface {
    *   headers, authentication, timeouts, or any other configuration
    *   necessary for making HTTP requests.
    */
-   function getRequestOptions(array $transformedLogData): array;
+  function getRequestOptions(array $transformedLogData): array;
 
   /**
    * Transforms log data into the format required by the API.

--- a/src/Controller/MonitorController.php
+++ b/src/Controller/MonitorController.php
@@ -31,9 +31,9 @@ class MonitorController extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('monitor.storage'),
-      $container->get('monitor.drupal.version.manager'),
-      $container->get('monitor.php.version.manager'),
+        $container->get('monitor.storage'),
+        $container->get('monitor.drupal.version.manager'),
+        $container->get('monitor.php.version.manager'),
     );
   }
 
@@ -52,12 +52,12 @@ class MonitorController extends ControllerBase {
     };
 
     $globals['drupal'] = [
-      'version' => $this->drupalVersionManager->getCurrentVersion(),
-      'changelogUrl' => $this->drupalVersionManager->getCurrentReleaseNotes(),
+        'version' => $this->drupalVersionManager->getCurrentVersion(),
+        'changelogUrl' => $this->drupalVersionManager->getCurrentReleaseNotes(),
     ];
     $globals['php'] = [
-      'version' => $this->phpVersionManager->getCurrentVersion(),
-      'changelogUrl' => $this->phpVersionManager->getCurrentReleaseNotes()
+        'version' => $this->phpVersionManager->getCurrentVersion(),
+        'changelogUrl' => $this->phpVersionManager->getCurrentReleaseNotes()
     ];
 
     //compare global versions to environment versions
@@ -74,12 +74,12 @@ class MonitorController extends ControllerBase {
 
     //TODO add proper cache tags
     return [
-      '#theme' => 'monitor',
-      'projects' => $projects,
-      'globals' => $globals,
-      '#cache' => [
-        'max-age' => 0
-      ],
+        '#theme' => 'monitor',
+        'projects' => $projects,
+        'globals' => $globals,
+        '#cache' => [
+            'max-age' => 0
+        ],
     ];
   }
 

--- a/src/CoralogixApiConsumer.php
+++ b/src/CoralogixApiConsumer.php
@@ -63,11 +63,11 @@ class CoralogixApiConsumer implements ApiConsumerInterface {
    */
   public function getRequestOptions(array $transformedLogData): array {
     return [
-      'headers' => [
-        'Content-Type' => 'application/json',
-        'Authorization' => 'Bearer ' . $this->apiKey,
-      ],
-      'body' => json_encode($transformedLogData),
+        'headers' => [
+            'Content-Type' => 'application/json',
+            'Authorization' => 'Bearer ' . $this->apiKey,
+        ],
+        'body' => json_encode($transformedLogData),
     ];
   }
 
@@ -84,12 +84,12 @@ class CoralogixApiConsumer implements ApiConsumerInterface {
     $level = $this->transformLoggingSeverityLevel($logData['data']['level']);
 
     return [
-      'applicationName' => $logData['project'] ?? 'UnknownProject',
-      'subsystemName' => $logData['environment'] ?? 'UnknownEnvironment',
-      'timestamp' => $logData['data']['timestamp'] ?? time(),
-      'severity' => $level,
-      'category' => $logData['data']['channel'] ?? null,
-      'text' => $logData['data']['message'] ?? 'No message provided',
+        'applicationName' => $logData['project'] ?? 'UnknownProject',
+        'subsystemName' => $logData['environment'] ?? 'UnknownEnvironment',
+        'timestamp' => $logData['data']['timestamp'] ?? time(),
+        'severity' => $level,
+        'category' => $logData['data']['channel'] ?? null,
+        'text' => $logData['data']['message'] ?? 'No message provided',
     ];
   }
 
@@ -104,14 +104,14 @@ class CoralogixApiConsumer implements ApiConsumerInterface {
    */
   private function transformLoggingSeverityLevel(int $drupalLogLevel): int {
     $mapping = [
-      RfcLogLevel::DEBUG => 1,   // Debug
-      RfcLogLevel::INFO => 3,    // Info
-      RfcLogLevel::NOTICE => 3,  // Info (nearest match)
-      RfcLogLevel::WARNING => 4, // Warn
-      RfcLogLevel::ERROR => 5,   // Error
-      RfcLogLevel::CRITICAL => 6,// Critical
-      RfcLogLevel::ALERT => 6,   // Critical (nearest match)
-      RfcLogLevel::EMERGENCY => 6  // Critical (nearest match)
+        RfcLogLevel::DEBUG => 1,   // Debug
+        RfcLogLevel::INFO => 3,    // Info
+        RfcLogLevel::NOTICE => 3,  // Info (nearest match)
+        RfcLogLevel::WARNING => 4, // Warn
+        RfcLogLevel::ERROR => 5,   // Error
+        RfcLogLevel::CRITICAL => 6,// Critical
+        RfcLogLevel::ALERT => 6,   // Critical (nearest match)
+        RfcLogLevel::EMERGENCY => 6  // Critical (nearest match)
     ];
 
     return $mapping[$drupalLogLevel] ?? 3; // Default to Info if undefined

--- a/src/Plugin/QueueWorker/MonitorQueueWorker.php
+++ b/src/Plugin/QueueWorker/MonitorQueueWorker.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\monitor\Plugin\QueueWorker;
+
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\Attribute\QueueWorker;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\Core\StringTranslation\TranslatableMarkup;
+use Drupal\monitor\LogManager;
+use Drupal\monitor\MonitorStorage;
+use Drupal\monitor\Plugin\rest\resource\MonitorResource;
+use Drupal\monitor\SendToMonitorFlag;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Defines 'monitor_queueworker' queue worker.
+ */
+#[QueueWorker(
+  id: 'monitor_queueworker',
+  title: new TranslatableMarkup('QueueWorker'),
+  cron: ['time' => 60],
+)]
+class MonitorQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  protected MonitorStorage $monitorStorage;
+  protected LogManager $logManager;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, MonitorStorage $monitorStorage, LogManager $logManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->monitorStorage = $monitorStorage;
+    $this->logManager = $logManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($data): void {
+    try {
+      $this->monitorStorage->setInstanceData($data[MonitorResource::IDENTIFIER], $data[MonitorResource::ENVIRONMENT], $data['data']);
+    } catch (\Exception $e) {
+      \Drupal::logger('monitor')->error('Could not process Item in Monitor Queue {data}', ['data' => json_encode($data), SendToMonitorFlag::SEND_TO_MONITOR_KEY->value => false]);
+      $this->logManager->alertByMail([$e->getMessage()]);
+    }
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('monitor.storage'),
+      $container->get('monitor.log_manager')
+    );
+  }
+}

--- a/src/Plugin/rest/resource/InstanceResource.php
+++ b/src/Plugin/rest/resource/InstanceResource.php
@@ -83,7 +83,7 @@ class InstanceResource extends MonitorResource {
     $this->checkForProjectAndEnvironment($data);
 
     if ($this->logManager->dataFromAllowedEnvironment($data)) {
-      $this->update($data);
+      $this->sendToQueue($data);
     }
 
     // Return the newly created record in the response body.
@@ -97,7 +97,7 @@ class InstanceResource extends MonitorResource {
    * @return void
    * @throws TempStoreException
    */
-  private function update(array $data): void {
+  private function sendToQueue(array $data): void {
     if(!$this->queue->createItem($data)) {
       \Drupal::logger('monitor')->error('Could not add item to queue. {itemData}', ['itemData' => json_encode($data), SendToMonitorFlag::SEND_TO_MONITOR_KEY->value => false]);
 

--- a/src/Plugin/rest/resource/InstanceResource.php
+++ b/src/Plugin/rest/resource/InstanceResource.php
@@ -45,7 +45,7 @@ class InstanceResource extends MonitorResource {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
     $this->monitorStorage = $monitorStorage;
     $this->logManager = $logManager;
-    $this->queue = $queue->get('monitor_queueworker', True);
+    $this->queue = $queue->get('monitor_queueworker', true);
   }
 
   /**

--- a/src/Plugin/rest/resource/LogResource.php
+++ b/src/Plugin/rest/resource/LogResource.php
@@ -37,12 +37,12 @@ class LogResource extends MonitorResource {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition): LogResource {
     return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->getParameter('serializer.formats'),
-      $container->get('logger.factory')->get('rest'),
-      $container->get('monitor.log_manager'),
+        $configuration,
+        $plugin_id,
+        $plugin_definition,
+        $container->getParameter('serializer.formats'),
+        $container->get('logger.factory')->get('rest'),
+        $container->get('monitor.log_manager'),
     );
   }
 
@@ -53,7 +53,7 @@ class LogResource extends MonitorResource {
    * @return ModifiedResourceResponse
    */
   public function post($data): ModifiedResourceResponse {
-    $this->validate($data);
+    $this->checkForProjectAndEnvironment($data);
 
     // Process and filter log through LogManager
     $this->logManager->processLog($data);

--- a/src/Plugin/rest/resource/MonitorResource.php
+++ b/src/Plugin/rest/resource/MonitorResource.php
@@ -3,6 +3,8 @@
 namespace Drupal\monitor\Plugin\rest\resource;
 
 use Drupal\Component\Plugin\DependentPluginInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
 use Drupal\monitor\MonitorStorage;
 use Drupal\rest\Plugin\ResourceBase;
 use Psr\Log\LoggerInterface;
@@ -40,11 +42,12 @@ class MonitorResource extends ResourceBase implements DependentPluginInterface {
    */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
-      $configuration,
-      $plugin_id,
-      $plugin_definition,
-      $container->getParameter('serializer.formats'),
-      $container->get('logger.factory')->get('rest'),
+        $configuration,
+        $plugin_id,
+        $plugin_definition,
+        $container->getParameter('serializer.formats'),
+        $container->get('logger.factory')->get('rest'),
+        $container->get('queue')
     );
   }
 
@@ -54,7 +57,7 @@ class MonitorResource extends ResourceBase implements DependentPluginInterface {
    * @param $data
    * @return void
    */
-  protected function validate($data): void {
+  protected function checkForProjectAndEnvironment($data): void {
     if (!isset($data[self::IDENTIFIER], $data[self::ENVIRONMENT])) {
       throw new UnprocessableEntityHttpException('Provide at least a project and its environment.');
     }


### PR DESCRIPTION
To ignore:
ApiConsumerInterface: linting
MonitorController: linting
CoralogixApiConsumer: linting

Refactor:
- Methodname of `filter` to `dataFromAllowedEnvironment`
- use `SendToMonitorFlag` from `instance` to determine if a log should be sent to the monitor. Which we should mostly not here, 'cause it is the monitor.
- use `alertByMail` method instead. The method is not implemented, but called by all cases where it will be good
- add a Queue to not overload the monitor